### PR TITLE
Fix: Download kind binary based on machine architecture

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -48,8 +48,15 @@
       args:
         creates: /usr/local/bin/kubectl
 
+    - name: Determine machine architecture
+      command: uname -m
+      register: architecture_info
+      changed_when: false
+
     - name: Download kind
-      shell: curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.22.0/kind-linux-amd64
+      shell: |
+        ARCH=$(echo "{{ architecture_info.stdout }}" | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')
+        curl -Lo ./kind "https://kind.sigs.k8s.io/dl/v0.22.0/kind-linux-${ARCH}"
       args:
         creates: ./kind
 


### PR DESCRIPTION
The Ansible playbook was previously hardcoding the amd64 version of the kind binary. This change modifies the playbook to:

1. Determine the machine architecture.
2. Download the appropriate kind binary (amd64 or arm64) for version v0.22.0 based on the detected architecture.

This fixes the "cannot execute binary file" error when deploying to EC2 instances with architectures other than amd64 (e.g., ARM-based Graviton instances).