### PR TITLE
Fix: Correct Ansible task order for architecture detection

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -35,6 +35,17 @@
         groups: docker
         append: yes
 
+    - name: Determine machine architecture
+      command: uname -m
+      register: architecture_info
+      changed_when: false
+
+    - name: Display architecture info
+      debug:
+        msg: >
+          Detected architecture (uname -m): {{ architecture_info.stdout }}.
+          Target ARCH for download: {% if architecture_info.stdout == 'x86_64' %}amd64{% elif architecture_info.stdout == 'aarch64' %}arm64{% else %}Unsupported/Unknown{% endif %}
+
     - name: Download kubectl
       shell: |
         ACTUAL_ARCH="{{ architecture_info.stdout }}"
@@ -56,17 +67,6 @@
 
     - name: Move kubectl to /usr/local/bin
       shell: mv ./kubectl /usr/local/bin/kubectl
-
-    - name: Determine machine architecture
-      command: uname -m
-      register: architecture_info
-      changed_when: false
-
-    - name: Display architecture info
-      debug:
-        msg: >
-          Detected architecture (uname -m): {{ architecture_info.stdout }}.
-          Target ARCH for download: {% if architecture_info.stdout == 'x86_64' %}amd64{% elif architecture_info.stdout == 'aarch64' %}arm64{% else %}Unsupported/Unknown{% endif %}
 
     - name: Download kind
       shell: |


### PR DESCRIPTION
This commit fixes an "undefined variable" error for `architecture_info` that occurred during the "Download kubectl" task.

The `Determine machine architecture` task, which defines the `architecture_info` variable, and the associated `Display architecture info` debug task were incorrectly placed after the "Download kubectl" task that relied on this variable.

The order of tasks has been corrected to ensure that `architecture_info` is defined before it is used by either the `kubectl` or `kind` download tasks. The corrected order is:
1. Determine machine architecture
2. Display architecture info
3. Download kubectl and related tasks
4. Download kind and related tasks

This should resolve the playbook failure caused by the undefined variable.