### PR TITLE
Fix: Set imagePullPolicy to Always for selenium/node-chrome

### DIFF
--- a/kubernetes/selenium-node-chrome-deployment.yml
+++ b/kubernetes/selenium-node-chrome-deployment.yml
@@ -17,6 +17,7 @@ spec:
       containers:
       - name: selenium-node-chrome
         image: selenium/node-chrome:125.0
+        imagePullPolicy: Always
         ports:
         - containerPort: 5555 # Default port for Chrome node
         env:


### PR DESCRIPTION
This change explicitly sets the imagePullPolicy to Always for the selenium/node-chrome deployment. This will ensure that Kubernetes always attempts to pull the image from Docker Hub, which can help resolve issues where the image is reported as not found despite being available.