### PR TITLE
fix: Address SSH host key and Python interpreter issues

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -82,6 +82,8 @@ jobs:
           ssh -o StrictHostKeyChecking=no -i ~/.ssh/id_rsa ec2-user@$(terraform -chdir=terraform output -raw master_public_ip) echo "SSH Success"
 
       - name: Run Ansible Playbook
+        env:
+          ANSIBLE_HOST_KEY_CHECKING: "False"
         run: |
           ansible-playbook -i ansible/inventory.ini ansible/playbook.yml --extra-vars "dockerhub_email=${{ secrets.DOCKERHUB_EMAIL }} dockerhub_username=${{ secrets.DOCKERHUB_USERNAME }} dockerhub_password=${{ secrets.DOCKERHUB_PASSWORD }}"
 

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -15,7 +15,7 @@
 # workers
 - hosts: all
   become: yes
-  gather_facts: yes # Changed to yes to use inventory_hostname reliably
+  gather_facts: no # Changed to no, will rely on manual fact gathering in pre_tasks
 
   pre_tasks:
     - name: Bootstrap Python 3.8 using raw command


### PR DESCRIPTION
This commit aims to resolve two issues encountered during Ansible execution:
1. SSH host key verification failures for worker nodes.
2. Python 3.8 interpreter not being found on the master node during initial fact gathering.

Changes:
- In `.github/workflows/deploy.yml`:
  - Set `ANSIBLE_HOST_KEY_CHECKING: "False"` as an environment variable for the Ansible playbook execution step to prevent SSH host key verification failures.
- In `ansible/playbook.yml`:
  - Changed `gather_facts: yes` to `gather_facts: no` at the play level. This defers fact gathering until after `pre_tasks` (which include Python 3.8 installation and a manual `setup:` call), preventing errors if the specified Python interpreter isn't immediately available.

Note: My previous analysis indicated these configurations were already in place. This commit ensures this desired state is officially recorded.