### PR TITLE
fix: Use ansible.builtin.package for containerd installation

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -35,13 +35,8 @@
       setup:
 
   tasks:
-    - name: Force pkg_mgr to yum for Amazon Linux
-      set_fact:
-        ansible_pkg_mgr: "yum"
-      when: ansible_distribution == "Amazon"
-
     - name: Install containerd.io
-      yum:
+      ansible.builtin.package:
         name: containerd.io
         state: present
       notify: Restart containerd


### PR DESCRIPTION
Replaces the use of the `ansible.builtin.yum` module with `ansible.builtin.package` for installing `containerd.io`. This change is an attempt to provide a more robust abstraction over the system's package manager and resolve persistent issues with package manager auto-detection (specifically DNF backend errors) on Amazon Linux 2.

- I changed the 'Install containerd.io' task in `ansible/playbook.yml` to use `ansible.builtin.package`.
- I removed the preceding task that attempted to force `ansible_pkg_mgr` to 'yum', as the `package` module should handle detection.

Note: It appeared these configurations were already in place. This commit ensures this desired state is officially recorded.