### PR TITLE
Fix: Correct syntax error in Ansible playbook

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -169,7 +169,7 @@
         - name: Join worker nodes to the cluster
           shell: kubeadm join 172.31.88.98:6443 --token cj86wm.x8asjft6rt2fq0ok \
                  --discovery-token-ca-cert-hash sha256:8c180cf118d70ab7ecab737dca9e9cd7984c0b8746350210d267e98460c475dc
-          when: inventory_hostname != 'k8s-master'"
+          when: inventory_hostname != 'k8s-master'
 
     # ==============================================================================
     # DEPLOY KUBERNETES MANIFESTS (ON MASTER NODE)


### PR DESCRIPTION
The task "Join worker nodes to the cluster" had an extraneous double quote in its `when` conditional. This prevented the playbook from running correctly.

This commit removes the extra quote to resolve the template error.