### PR TITLE
Fix: Improve node join reliability

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -165,10 +165,15 @@
           environment:
             KUBECONFIG: /etc/kubernetes/admin.conf
           when: inventory_hostname == 'k8s-master'
+
+        - name: Reset Kubernetes components on worker nodes
+          shell: kubeadm reset -f
+          when: inventory_hostname != 'k8s-master'
+          ignore_errors: yes
     
         - name: Join worker nodes to the cluster
           shell: kubeadm join 172.31.88.98:6443 --token cj86wm.x8asjft6rt2fq0ok \
-                 --discovery-token-ca-cert-hash sha256:8c180cf118d70ab7ecab737dca9e9cd7984c0b8746350210d267e98460c475dc
+                 --discovery-token-ca-cert-hash sha256:8c180cf118d70ab7ecab737dca9e9cd7984c0b8746350210d267e98460c475dc --ignore-preflight-errors=FileExisting-tc
           when: inventory_hostname != 'k8s-master'
 
     # ==============================================================================


### PR DESCRIPTION
This commit introduces two changes to address errors during node joins:

1.  Adds a reset task before attempting to join nodes. This helps clean up any lingering state from previous failed attempts.
2.  Modifies the join command to include `--ignore-preflight-errors=FileExisting-tc` to handle a persistent warning about the `tc` tool not being found in the system path, which could otherwise halt the join process.