### PR TITLE
Refactor: Improve K8s cluster setup in Ansible

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -34,14 +34,11 @@
     - name: Manually gather facts using new interpreter
       setup:
 
-  tasks:
-    - name: Set up Kubernetes cluster on Amazon Linux 2
-  hosts: all
-  become: yes
   vars:
     k8s_version: "1.29"
 
   tasks:
+    # - name: Set up Kubernetes cluster on Amazon Linux 2 # This task name is redundant as the play itself describes this.
     - name: Install yum-utils
       shell: yum install -y yum-utils
       when: ansible_distribution == "Amazon"
@@ -160,21 +157,28 @@
             group: ec2-user
             mode: '0600'
 
+        - name: Generate join command for worker nodes
+          shell: kubeadm token create --print-join-command
+          register: join_command_raw
+
+        - name: Set join command as a fact
+          set_fact:
+            join_command: "{{ join_command_raw.stdout }}"
+
         - name: Deploy Flannel CNI plugin
           shell: kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml
           environment:
             KUBECONFIG: /etc/kubernetes/admin.conf
-          when: inventory_hostname == 'k8s-master'
+      when: inventory_hostname == 'k8s-master'
 
-        - name: Reset Kubernetes components on worker nodes
-          shell: kubeadm reset -f
-          when: inventory_hostname != 'k8s-master'
-          ignore_errors: yes
-    
-        - name: Join worker nodes to the cluster
-          shell: kubeadm join 172.31.88.98:6443 --token cj86wm.x8asjft6rt2fq0ok \
-                 --discovery-token-ca-cert-hash sha256:8c180cf118d70ab7ecab737dca9e9cd7984c0b8746350210d267e98460c475dc --ignore-preflight-errors=FileExisting-tc
-          when: inventory_hostname != 'k8s-master'
+    - name: Reset Kubernetes components on worker nodes
+      shell: kubeadm reset -f
+      when: inventory_hostname != 'k8s-master'
+      ignore_errors: yes
+
+    - name: Join worker nodes to the cluster
+      shell: "{{ hostvars['k8s-master']['join_command'] }} --ignore-preflight-errors=FileExisting-tc"
+      when: inventory_hostname != 'k8s-master'
 
     # ==============================================================================
     # DEPLOY KUBERNETES MANIFESTS (ON MASTER NODE)


### PR DESCRIPTION
This commit addresses several critical issues in the Ansible playbook for Kubernetes cluster provisioning:

1.  **Corrected Playbook Structure:**
    - Resolved duplicate key warnings (`hosts`, `become`, `tasks`) by consolidating the playbook into a single, coherent play definition. `pre_tasks` and `vars` are now correctly scoped.

2.  **Targeted `kubeadm init` Execution:**
    - Ensured the `Master Node Setup Block`, including the `kubeadm init` command and other master-specific setup tasks, runs exclusively on the `k8s-master` node by applying the `when: inventory_hostname == 'k8s-master'` condition to the block.

3.  **Dynamic `kubeadm join` Command:**
    - The `kubeadm join` command for worker nodes is now dynamically generated on the master node after `kubeadm init` completes (using `kubeadm token create --print-join-command`).
    - This join command is stored as a fact on the master and then used by worker nodes via `hostvars`, ensuring they always use the correct, current token, master IP, and discovery hash.
    - The static join command has been removed.

4.  **Maintained Worker Node Reset:**
    - The task to `kubeadm reset -f` on worker nodes before joining is preserved.
    - The `--ignore-preflight-errors=FileExisting-tc` flag on the join command is also kept.

These changes should lead to a more reliable and correct Kubernetes cluster initialization process.